### PR TITLE
[APT26]

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -182,5 +182,8 @@ module Greenlight
 
     # Default admin password
     config.admin_password_default = ENV['ADMIN_PASSWORD'] || 'administrator'
+
+    # Configurar cantidad de dias de gracia para vencimiento de licencias
+    config.grace_days_for_use = ENV['GRACE_DAYS_FOR_USE']
   end
 end


### PR DESCRIPTION
[APT26] Implementación de validación de días de gracia pos-vencimiento de licencia para impedir inicio de conferencias. Correccion